### PR TITLE
Strip possible ytdl:// protocol string in path

### DIFF
--- a/youtube-quality.lua
+++ b/youtube-quality.lua
@@ -179,6 +179,8 @@ function download_formats()
 
     local url = mp.get_property("path")
 
+    url = string.gsub(url, "ytdl://", "") -- Strip possible ytdl:// prefix.
+
     -- don't fetch the format list if we already have it
     if format_cache[url] ~= nil then 
         local res = format_cache[url]


### PR DESCRIPTION
When opening YouTube URL's via the ytdl:// protocol (https://mpv.io/manual/master/#protocols) the protocol string is left in the path, causing issues with quality retrieval part, so we have to strip it.